### PR TITLE
Output attributes in alphabetical rather than random order

### DIFF
--- a/hamlpy/elements.py
+++ b/hamlpy/elements.py
@@ -135,7 +135,9 @@ class Element(object):
 
                 # Parse string as dictionary
                 attributes_dict = eval(attribute_dict_string)
-                for k, v in attributes_dict.items():
+                for k in sorted(attributes_dict.keys()):
+                    v = attributes_dict[k]
+
                     if k != 'id' and k != 'class':
                         if isinstance(v, NoneType):
                             self.attributes += "%s " % (k,)

--- a/hamlpy/test/hamlpy_test.py
+++ b/hamlpy/test/hamlpy_test.py
@@ -368,7 +368,7 @@ class HamlPyTest(unittest.TestCase):
         hamlParser = hamlpy.Compiler(options_dict={'attr_wrapper': '"'})
         result = hamlParser.process(haml)
         self.assertEqual(result,
-                         '''<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+                         '''<html lang="en" xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
   <body id="main">
     <div class="wrap">
       <a href="/"></a>

--- a/hamlpy/test/templates/multiLineDict.html
+++ b/hamlpy/test/templates/multiLineDict.html
@@ -1,5 +1,5 @@
 <div class='row'>
-  <img src='/static/imgs/ibl_logo{{id}}.gif' alt='IBL Logo' />
+  <img alt='IBL Logo' src='/static/imgs/ibl_logo{{id}}.gif' />
   <br />
-  <img src='/static/imgs/ibl_logo.gif' alt='IBL Logo{{id}}' />
+  <img alt='IBL Logo{{id}}' src='/static/imgs/ibl_logo.gif' />
 </div>

--- a/hamlpy/test/test_elements.py
+++ b/hamlpy/test/test_elements.py
@@ -49,7 +49,7 @@ class TestElement(object):
             eq_(s1['b'],None)
             eq_(s1['c'],2)
 
-            eq_(sut.attributes, "a='something' c='2' b")
+            eq_(sut.attributes, "a='something' b c='2'")
 
         def test_pulls_tag_name_off_front(self):
             sut = Element('%div.class')


### PR DESCRIPTION
Fixes https://github.com/Psycojoker/django-hamlpy/issues/2 until we implement a proper attribute dict parser.