### PR TITLE
Improve element parsing

### DIFF
--- a/hamlpy/elements.py
+++ b/hamlpy/elements.py
@@ -17,7 +17,7 @@ class Element(object):
     DEFAULT_TAG = 'div'
 
     ELEMENT_REGEX = regex.compile(r"""
-        (?P<tag>%\w+(\:\w+)?)?
+        (?P<tag>%[\w\-]+(\:[\w\-]+)?)?
         (?P<id_and_classes>(\#|\.)[\w-]+)*
         (?P<attributes>\{.*\})?
         (?P<nuke_outer_whitespace>\>)?

--- a/hamlpy/elements.py
+++ b/hamlpy/elements.py
@@ -18,7 +18,7 @@ class Element(object):
 
     ELEMENT_REGEX = regex.compile(r"""
         (?P<tag>%\w+(\:\w+)?)?
-        (?P<id_and_classes>(\#|\.)\w[\w-]*)*
+        (?P<id_and_classes>(\#|\.)[\w-]+)*
         (?P<attributes>\{.*\})?
         (?P<nuke_outer_whitespace>\>)?
         (?P<nuke_inner_whitespace>\<)?

--- a/hamlpy/nodes.py
+++ b/hamlpy/nodes.py
@@ -277,8 +277,10 @@ class ElementNode(HamlNode):
     def _render_before(self, element):
         '''Render opening tag and inline content'''
         start = ["%s<%s" % (self.spaces, element.tag)]
-        if element.attributes:
-            start.append(' ' + self.replace_inline_variables(element.attributes))
+
+        attributes = element.render_attributes()
+        if attributes:
+            start.append(' ' + self.replace_inline_variables(attributes))
 
         content = self._render_inline_content(self.element.inline_content)
 

--- a/hamlpy/test/templates/classIdMixtures.hamlpy
+++ b/hamlpy/test/templates/classIdMixtures.hamlpy
@@ -1,2 +1,4 @@
 %div#Article.article.entry{'id':'123', 'class':'true'}
   Now this is interesting
+%div.article.entry#Article{'id':'123', 'class':'true'}
+  Now this is really interesting

--- a/hamlpy/test/templates/classIdMixtures.html
+++ b/hamlpy/test/templates/classIdMixtures.html
@@ -1,3 +1,6 @@
 <div id='Article_123' class='article entry true'>
   Now this is interesting
 </div>
+<div id='Article_123' class='article entry true'>
+  Now this is really interesting
+</div>

--- a/hamlpy/test/templates/simple.hamlpy
+++ b/hamlpy/test/templates/simple.hamlpy
@@ -1,5 +1,5 @@
 %div 
-  %div.someClass 
+  %ng-repeat.someClass
     Here we go
     And more
 %div More

--- a/hamlpy/test/templates/simple.html
+++ b/hamlpy/test/templates/simple.html
@@ -1,7 +1,7 @@
 <div>
-  <div class='someClass'>
+  <ng-repeat class='someClass'>
     Here we go
     And more
-  </div>
+  </ng-repeat>
 </div>
 <div>More</div>

--- a/hamlpy/test/test_compiler.py
+++ b/hamlpy/test/test_compiler.py
@@ -28,6 +28,9 @@ class CompilerTest(unittest.TestCase):
         # multiple classes
         self._test('%div.someClass.anotherClass Some text', "<div class='someClass anotherClass'>Some text</div>")
 
+        # class can come before id
+        self._test('%div.someClass#someId', "<div id='someId' class='someClass'></div>")
+
     def test_attribute_dictionaries(self):
         # attribute dictionaries
         self._test("%html{'xmlns':'http://www.w3.org/1999/xhtml', 'xml:lang':'en', 'lang':'en'}",

--- a/hamlpy/test/test_elements.py
+++ b/hamlpy/test/test_elements.py
@@ -43,6 +43,15 @@ class ElementTest(unittest.TestCase):
         sut = Element('%div#someId.someClass.anotherClass')
         assert sut.classes == ['someClass', 'anotherClass']
 
+        # classes before id
+        sut = Element('%div.someClass.anotherClass#someId')
+        assert sut.classes == ['someClass', 'anotherClass']
+
+        # classes can contain hypens and underscores
+        sut = Element('%div.-some-class-._another_class_')
+        assert sut.classes == ['-some-class-', '_another_class_']
+
+        # no class
         sut = Element('%div#someId')
         assert sut.classes == []
 

--- a/hamlpy/test/test_elements.py
+++ b/hamlpy/test/test_elements.py
@@ -18,11 +18,15 @@ class ElementTest(unittest.TestCase):
         s2 = sut._escape_attribute_quotes('''blah's blah''s {% url 'blah' %} blah's blah''s''')
         assert s2 == r"blah\'s blah\'\'s {% url 'blah' %} blah\'s blah\'\'s"
 
-    def test_pulls_tag_name_off_front(self):
+    def test_parses_tag(self):
         sut = Element('%span.class')
         assert sut.tag == 'span'
 
-    def test_default_tag_is_div(self):
+        # can have namespace and hypens
+        sut = Element('%ng-tags:ng-repeat.class')
+        assert sut.tag == 'ng-tags:ng-repeat'
+
+        # defaults to div
         sut = Element('.class#id')
         assert sut.tag == 'div'
 

--- a/hamlpy/test/test_elements.py
+++ b/hamlpy/test/test_elements.py
@@ -2,6 +2,8 @@ from __future__ import print_function, unicode_literals
 
 import unittest
 
+from collections import OrderedDict
+
 from hamlpy.elements import Element
 
 
@@ -17,8 +19,8 @@ class ElementTest(unittest.TestCase):
         assert s2 == r"blah\'s blah\'\'s {% url 'blah' %} blah\'s blah\'\'s"
 
     def test_pulls_tag_name_off_front(self):
-        sut = Element('%div.class')
-        assert sut.tag == 'div'
+        sut = Element('%span.class')
+        assert sut.tag == 'span'
 
     def test_default_tag_is_div(self):
         sut = Element('.class#id')
@@ -31,33 +33,32 @@ class ElementTest(unittest.TestCase):
         sut = Element('#someId.someClass')
         assert sut.id == 'someId'
 
-    def test_no_id_gives_empty_string(self):
         sut = Element('%div.someClass')
-        assert sut.id == ''
+        assert sut.id is None
 
-    def test_parses_class(self):
+    def test_parses_classes(self):
         sut = Element('%div#someId.someClass')
-        assert sut.classes == 'someClass'
+        assert sut.classes == ['someClass']
 
-    def test_properly_parses_multiple_classes(self):
         sut = Element('%div#someId.someClass.anotherClass')
-        assert sut.classes == 'someClass anotherClass'
+        assert sut.classes == ['someClass', 'anotherClass']
 
-    def test_no_class_gives_empty_string(self):
         sut = Element('%div#someId')
-        assert sut.classes == ''
+        assert sut.classes == []
 
     def test_attribute_dictionary_properly_parses(self):
         sut = Element("%html{'xmlns':'http://www.w3.org/1999/xhtml', 'xml:lang':'en', 'lang':'en'}")
-        assert "xmlns='http://www.w3.org/1999/xhtml'" in sut.attributes
-        assert "xml:lang='en'" in sut.attributes
-        assert "lang='en'" in sut.attributes
+
+        assert sut.attributes == OrderedDict([
+            ('xmlns', "http://www.w3.org/1999/xhtml"),
+            ('xml:lang', "en"),
+            ('lang', "en")
+        ])
 
     def test_attribute_merges_classes_properly(self):
         sut = Element("%div.someClass.anotherClass{'class':'hello'}")
-        assert 'someClass' in sut.classes
-        assert 'anotherClass' in sut.classes
-        assert 'hello' in sut.classes
+
+        assert sut.classes == ['someClass', 'anotherClass', 'hello']
 
     def test_attribute_merges_ids_properly(self):
         sut = Element("%div#someId{'id':'hello'}")
@@ -73,7 +74,7 @@ class ElementTest(unittest.TestCase):
 
     def test_does_not_close_a_non_self_closing_tag(self):
         sut = Element("%div")
-        assert sut.self_close == False
+        assert sut.self_close is False
 
     def test_can_close_a_non_self_closing_tag(self):
         sut = Element("%div/")
@@ -94,6 +95,9 @@ class ElementTest(unittest.TestCase):
     def test_multiline_attributes(self):
         sut = Element("""%link{'rel': 'stylesheet', 'type': 'text/css',
             'href': '/long/url/to/stylesheet/resource.css'}""")
-        assert "href='/long/url/to/stylesheet/resource.css'" in sut.attributes
-        assert "type='text/css'" in sut.attributes
-        assert "rel='stylesheet'" in sut.attributes
+
+        assert sut.attributes == OrderedDict([
+            ('rel', "stylesheet"),
+            ('type', "text/css"),
+            ('href', "/long/url/to/stylesheet/resource.css")
+        ])

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
 pygments
 markdown
+regex
 six


### PR DESCRIPTION
* Adds support for classes being before ids (fixes https://github.com/jessemiller/HamlPy/issues/126)
* Adds support for tags with hyphens (fixes #6)
* `Element` class now stores unrendered state and `render_attributes` does rendering of HTML attributes when required. This makes it easier to test.