### PR TITLE
Fixed some incorrect relative imports

### DIFF
--- a/hamlpy/hamlpy_watcher.py
+++ b/hamlpy/hamlpy_watcher.py
@@ -12,7 +12,7 @@ import codecs
 import os
 import os.path
 import time
-import hamlpy
+from . import hamlpy
 from . import nodes as hamlpynodes
 
 try:

--- a/hamlpy/templatize.py
+++ b/hamlpy/templatize.py
@@ -13,7 +13,7 @@ try:
 except ImportError as e:
     _django_available = False
 
-import hamlpy
+from . import hamlpy
 import os
 
 


### PR DESCRIPTION
Running on Python 3.4.3

Fixes an issue when trying to import hamlpy. It was loading all of the modules in the folder called 'hamlpy' instead of loading the module itself.

Before:

```
import hamlpy
print(dir(hamlpy))
```

You will get something like:

`[<python attributes>, 'attribute_dict_parser', 'elements', 'hamlpy_watcher', 'nodes', 'templatize', 'unicode_literals']`

Which are simply the module names in the hamlpy/ folder. After the import fix you get:

`[<python attributes>, 'Compiler', 'HamlNode', 'OptionParser', 'RootNode', 'VALID_EXTENSIONS', 'convert_files', 'create_node', 'print_function', 'unicode_literals']`

Which are the actual contents of hamlpy.py. 