### PR TITLE
Added a --once flag for one time compiles

### DIFF
--- a/hamlpy/hamlpy_watcher.py
+++ b/hamlpy/hamlpy_watcher.py
@@ -101,20 +101,20 @@ def watch_folder():
         })
         
         hamlpynodes.TagNode.may_contain['for'] = 'else'
+
+    # Compile once, then exist
+    if args.once:
+        (total_files, num_failed) = _watch_folder(input_folder, output_folder, compiler_args)
+        print('Compiled %d of %d files.' % (total_files - num_failed, total_files))
+        if num_failed == 0:
+            print('All files compiled successfully.')
+        else:
+            print('Some files have errors.')
+        sys.exit(num_failed)
     
     while True:
         try:
-            (total_files, num_failed) = _watch_folder(input_folder, output_folder, compiler_args)
-            
-            # Stop after the first round of compiling 
-            if args.once:
-                print('Compiled %d of %d files.' % (total_files - num_failed, total_files))
-                if num_failed == 0:
-                    print('All files compiled successfully.')
-                else:
-                    print('Some files have errors.')
-                sys.exit(num_failed)
-
+            _watch_folder(input_folder, output_folder, compiler_args)
             time.sleep(args.refresh)
         except KeyboardInterrupt:
             # allow graceful exit (no stacktrace output)
@@ -140,13 +140,11 @@ def _watch_folder(folder, destination, compiler_args):
                     os.makedirs(compiled_folder)
                 
                 compiled_path = _compiled_path(compiled_folder, filename)
-                if (not fullpath in compiled or
-                    compiled[fullpath] < mtime or
-                    not os.path.isfile(compiled_path)):
-                    if not compile_file(fullpath, compiled_path, compiler_args):
-                        num_failed += 1
+                if not fullpath in compiled or compiled[fullpath] < mtime or not os.path.isfile(compiled_path):
                     compiled[fullpath] = mtime
                     total_files += 1
+                    if not compile_file(fullpath, compiled_path, compiler_args):
+                        num_failed += 1
 
     return (total_files, num_failed)
 

--- a/hamlpy/hamlpy_watcher.py
+++ b/hamlpy/hamlpy_watcher.py
@@ -42,14 +42,15 @@ class StoreNameValueTagPair(argparse.Action):
 
 arg_parser = argparse.ArgumentParser()
 arg_parser.add_argument('-v', '--verbose', help = 'Display verbose output', action = 'store_true')
-arg_parser.add_argument('-i', '--input-extension', metavar = 'EXT', default = '.hamlpy', help = 'The file extensions to look for', type = str, nargs = '+')
+arg_parser.add_argument('-i', '--input-extension', metavar = 'EXT', default = '.hamlpy', help = 'The file extensions to look for.', type = str, nargs = '+')
 arg_parser.add_argument('-ext', '--extension', metavar = 'EXT', default = Options.OUTPUT_EXT, help = 'The output file extension. Default is .html', type = str)
-arg_parser.add_argument('-r', '--refresh', metavar = 'S', default = Options.CHECK_INTERVAL, help = 'Refresh interval for files. Default is {} seconds'.format(Options.CHECK_INTERVAL), type = int)
+arg_parser.add_argument('-r', '--refresh', metavar = 'S', default = Options.CHECK_INTERVAL, help = 'Refresh interval for files. Default is {} seconds. Ignored if the --once flag is set.'.format(Options.CHECK_INTERVAL), type = int)
 arg_parser.add_argument('input_dir', help = 'Folder to watch', type = str)
 arg_parser.add_argument('output_dir', help = 'Destination folder', type = str, nargs = '?')
 arg_parser.add_argument('--tag', help = 'Add self closing tag. eg. --tag macro:endmacro', type = str, nargs = 1, action = StoreNameValueTagPair)
 arg_parser.add_argument('--attr-wrapper', dest = 'attr_wrapper', type = str, choices = ('"', "'"), default = "'", action = 'store', help = "The character that should wrap element attributes. This defaults to ' (an apostrophe).")
-arg_parser.add_argument('--jinja', help = 'Makes the necessary changes to be used with Jinja2', default = False, action = 'store_true')
+arg_parser.add_argument('--jinja', help = 'Makes the necessary changes to be used with Jinja2.', default = False, action = 'store_true')
+arg_parser.add_argument('--once', help = 'Runs the compiler once and exits on completion. Returns a non-zero exit code if there were any compile errors.', default = False, action = 'store_true')
 
 def watched_extension(extension):
     """Return True if the given extension is one of the watched extensions"""
@@ -103,7 +104,17 @@ def watch_folder():
     
     while True:
         try:
-            _watch_folder(input_folder, output_folder, compiler_args)
+            (total_files, num_failed) = _watch_folder(input_folder, output_folder, compiler_args)
+            
+            # Stop after the first round of compiling 
+            if args.once:
+                print('Compiled %d of %d files.' % (total_files - num_failed, total_files))
+                if num_failed == 0:
+                    print('All files compiled successfully.')
+                else:
+                    print('Some files have errors.')
+                sys.exit(num_failed)
+
             time.sleep(args.refresh)
         except KeyboardInterrupt:
             # allow graceful exit (no stacktrace output)
@@ -111,7 +122,10 @@ def watch_folder():
 
 def _watch_folder(folder, destination, compiler_args):
     """Compares "modified" timestamps against the "compiled" dict, calls compiler
-    if necessary."""
+    if necessary. Returns a tuple of the number of files hit and the number
+    of failed compiles"""
+    total_files = 0
+    num_failed = 0
     for dirpath, dirnames, filenames in os.walk(folder):
         for filename in filenames:
             # Ignore filenames starting with ".#" for Emacs compatibility
@@ -129,14 +143,19 @@ def _watch_folder(folder, destination, compiler_args):
                 if (not fullpath in compiled or
                     compiled[fullpath] < mtime or
                     not os.path.isfile(compiled_path)):
-                    compile_file(fullpath, compiled_path, compiler_args)
+                    if not compile_file(fullpath, compiled_path, compiler_args):
+                        num_failed += 1
                     compiled[fullpath] = mtime
+                    total_files += 1
+
+    return (total_files, num_failed)
 
 def _compiled_path(destination, filename):
     return os.path.join(destination, filename[:filename.rfind('.')] + Options.OUTPUT_EXT)
 
 def compile_file(fullpath, outfile_name, compiler_args):
-    """Calls HamlPy compiler."""
+    """Calls HamlPy compiler. Returns True if the file was compiled and 
+    written successfully."""
     if Options.VERBOSE:
         print('%s %s -> %s' % (strftime("%H:%M:%S"), fullpath, outfile_name))
     try:
@@ -147,10 +166,14 @@ def compile_file(fullpath, outfile_name, compiler_args):
         output = compiler.process_lines(haml_lines)
         outfile = codecs.open(outfile_name, 'w', encoding = 'utf-8')
         outfile.write(output)
+
+        return True
     except Exception as e:
         # import traceback
         print("Failed to compile %s -> %s\nReason:\n%s" % (fullpath, outfile_name, e))
         # print traceback.print_exc()
+
+    return False
 
 if __name__ == '__main__':
     watch_folder()


### PR DESCRIPTION
The purpose of this is to help reinforce the paradigm of keeping compiled assets/templates out of your repo and instead building them when deploying.

The current hamlpy-watcher does not have good support for one time compiles because the process stays open and you don't know when it finishes, or if it was successful. 

This flag is useful if you have an automated deploy script. You can also check the exit code on the process to see if any files failed to compile (returns the # of failed compilations, or 0 if successful).

Example:

    $ hamlpy-watcher --once web/templates web/templates/__compiled__
    Compiled 13 of 13 files.
    All files compiled successfully.
    $